### PR TITLE
temp variable registers were accidentally commented out. uncommented them back.

### DIFF
--- a/registers.v
+++ b/registers.v
@@ -21,10 +21,10 @@ parameter register_size = 8;
 integer i;
 
 // 16 -> 8 bit registers
-//reg [register_size-1:0] registers [0:register_count-1];
+reg [register_size-1:0] registers [0:register_count-1];
 
 // Temporary variable to hold data value stored in addressed register slot
-//reg [register_size-1:0] datatogoout;
+reg [register_size-1:0] datatogoout;
 
 //Only run when we detect a positive clock edge rise or a positive reset edge rise
 always @(posedge clock or posedge reset) begin

--- a/registers.v.bak
+++ b/registers.v.bak
@@ -26,11 +26,10 @@ reg [register_size-1:0] registers [0:register_count-1];
 // Temporary variable to hold data value stored in addressed register slot
 reg [register_size-1:0] datatogoout;
 
-// Value to update register slot too
-input wire [register_size-1:0] data_in;
-
 //Only run when we detect a positive clock edge rise or a positive reset edge rise
 always @(posedge clock or posedge reset) begin
+
+#4 // delay for writing to register
 
 	// Reset all register slots back to 0 as well as output value being sent to the outside
 	if (reset==1) begin
@@ -49,7 +48,7 @@ always @(posedge clock or posedge reset) begin
 	datatogoout <= registers[addr];
 end
 
-// Send out the addressed register slot's value
-assign data_out = datatogoout;
+// Send out the addressed register slot's value, delay for ALU ops
+assign #4 data_out = datatogoout;
 
 endmodule


### PR DESCRIPTION
temp variable registers were accidentally commented out. uncommented them back.